### PR TITLE
Fix missing 0.2.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [Unreleased] - ReleaseDate
 
-## [Unreleased - `embedded-graphics` repository] - ReleaseDate
+## [0.2.1] - 2020-07-29
 
 > Note: PR numbers from this point onwards are from the old `embedded-graphics/embedded-graphics` repository. New PR numbers above this note refer to PRs in the `embedded-graphics/tinybmp` repository.
 
@@ -20,8 +20,6 @@
 ### Added
 
 - **(breaking)** #266 Added [image](https://crates.io/crates/image) support and PNG export. See the `README.md` for information about how to use these features. The API for creating windows was changed to make the output settings independent of the `Window` type. The pixel scaling and theme settings were moved to a new `OutputSettings` struct, that can be built using the `OutputSettingsBuilder`. `WindowBuilder` was removed and replaced by a `Window::new(title, &output_settings)` function.
-
-### Changed
 
 ## [0.2.0-beta.2] - 2020-02-17
 
@@ -56,6 +54,6 @@
 <!-- next-url -->
 
 [unreleased]: https://github.com/embedded-graphics/simulator/compare/after-split...HEAD
-[unreleased - `embedded-graphics` repository]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-simulator-v0.2.0...before-split
-[0.2.0]: https://github.com/embedded-graphics/embedded-graphics-simulator/compare/embedded-graphics-simulator-v0.2.0-beta.2...embedded-graphics-simulator-v0.2.0
+[0.2.1]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-simulator-v0.2.0...embedded-graphics-simulator-v0.2.1
+[0.2.0]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-simulator-v0.2.0-beta.2...embedded-graphics-simulator-v0.2.0
 [0.2.0-beta.2]: https://github.com/embedded-graphics/embedded-graphics/compare/embedded-graphics-simulator-v0.2.0-alpha.1...embedded-graphics-simulator-v0.2.0-beta.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.2.0"
+version = "0.2.1"
 name = "embedded-graphics-simulator"
 description = "Embedded graphics simulator"
 authors = ["James Waples <james@wapl.es>"]

--- a/release.toml
+++ b/release.toml
@@ -1,9 +1,9 @@
 no-dev-version = true
 pre-release-replacements = [
-  {file="CHANGELOG.md", search="[Uu]nreleased", replace="{{version}}"},
-  {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}"},
-  {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
-  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate"},
-  {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[unreleased]: https://github.com/embedded-graphics/{{crate_name}}/compare/{{tag_name}}...HEAD"},
+  {file="CHANGELOG.md", prerelease=true, search="[Uu]nreleased", replace="{{version}}"},
+  {file="CHANGELOG.md", prerelease=true, search="\\.\\.\\.HEAD", replace="...{{tag_name}}"},
+  {file="CHANGELOG.md", prerelease=true, search="ReleaseDate", replace="{{date}}"},
+  {file="CHANGELOG.md", prerelease=true, search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate"},
+  {file="CHANGELOG.md", prerelease=true, search="<!-- next-url -->", replace="<!-- next-url -->\n[unreleased]: https://github.com/embedded-graphics/{{crate_name}}/compare/{{tag_name}}...HEAD"},
 ]
 tag-message = "Release {{crate_name}} {{version}}"


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add an example where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Fixes the metadata changes. Not sure how this happened. There's another change in `release.toml` that's unrelated, but required for `cargo release` to do the changelog replacements properly.

Closes #2 
