### PR TITLE
Update dependencies with alphas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,22 +27,16 @@ version = "0.32.2"
 optional = true
 
 [dependencies.embedded-graphics]
-# version = "=0.7.0-alpha.1"
-# TODO: Remove when a new e-g alpha is released
-git = "https://github.com/embedded-graphics/embedded-graphics"
+version = "=0.7.0-alpha.2"
 
 [dev-dependencies]
 chrono = "0.4.10"
 
 [dependencies.tinybmp]
-# version = "0.2.2"
-# TODO: Remove when a new e-g alpha is released
-git = "https://github.com/embedded-graphics/tinybmp"
+version = "0.3.0-alpha.1"
 
 [dependencies.tinytga]
-# version = "0.3.2"
-# TODO: Remove when a new e-g alpha is released
-git = "https://github.com/embedded-graphics/tinytga"
+version = "0.4.0-alpha.1"
 
 [features]
 default = [ "with-sdl" ]


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add an example where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Tinytga and tinybmp have fresh alpha releases that point to e-g-core
which now makes the simulator compile (locally at least...)

This will allow a simulator release of 0.3.0-alpha.1 to be made which will close #12.
