### PR TITLE
Reexport sdl2 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- [#16](https://github.com/embedded-graphics/simulator/pull/16) Re-export `sdl2` types.
+
 ## [0.3.0-alpha.1] - 2021-01-07
 
 ## [0.2.1] - 2020-07-29

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,20 @@ mod window;
 #[cfg(feature = "with-sdl")]
 pub use window::{SimulatorEvent, Window};
 
+/// Re-exported types from sdl2 crate.
+///
+/// The types in this module are used in the [`SimulatorEvent`] enum and are re-exported from the
+/// `sdl2` crate to make it possible to use them without adding a dependency to `sdl2`.
+///
+/// [`SimulatorEvent`]: ../enum.SimulatorEvent.html
+#[cfg(feature = "with-sdl")]
+pub mod sdl2 {
+    pub use sdl2::{
+        keyboard::{Keycode, Mod},
+        mouse::{MouseButton, MouseWheelDirection},
+    };
+}
+
 pub use crate::{
     display::SimulatorDisplay,
     output_settings::{OutputSettings, OutputSettingsBuilder},


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add an example where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds re-exports for the used `sdl2` types.

Closes #14
