### PR TITLE
Fix a misleading error message for scale == 0

### DIFF
--- a/src/output_settings.rs
+++ b/src/output_settings.rs
@@ -71,9 +71,7 @@ impl OutputSettingsBuilder {
     ///
     /// Panics if the scale is set to `0`.
     pub fn scale(mut self, scale: u32) -> Self {
-        if scale == 0 {
-            panic!("scale must be >= 0");
-        }
+        assert!(scale > 0, "scale must be > 0");
 
         self.scale = Some(scale);
 


### PR DESCRIPTION
"scale must be >= 0" would mean 0 is acceptable while it is not.