### PR TITLE
Add raw output to SimulatorDisplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- [#28](https://github.com/embedded-graphics/simulator/pull/28) Added `SimulatorDisplay::to_{be,le,ne}_bytes` to convert the display content to raw image data.
+
+### Fixed
+
+- [#28](https://github.com/embedded-graphics/simulator/pull/28) Fixed panic for zero sized `SimulatorDisplay`s.
+
 ## [0.3.0-beta.2] - 2021-05-04
 
 ### Added

--- a/examples/png-base64.rs
+++ b/examples/png-base64.rs
@@ -29,6 +29,6 @@ fn main() {
 
     println!(
         "<img src=\"data:image/png;base64,{}\">",
-        output_image.to_base64_png()
+        output_image.to_base64_png().unwrap()
     );
 }

--- a/src/output_settings.rs
+++ b/src/output_settings.rs
@@ -20,8 +20,8 @@ impl OutputSettings {
     {
         let width = display.size().width;
         let height = display.size().height;
-        let output_width = width * self.scale + (width - 1) * self.pixel_spacing;
-        let output_height = height * self.scale + (height - 1) * self.pixel_spacing;
+        let output_width = width * self.scale + width.saturating_sub(1) * self.pixel_spacing;
+        let output_height = height * self.scale + height.saturating_sub(1) * self.pixel_spacing;
 
         Size::new(output_width, output_height)
     }


### PR DESCRIPTION
This PR adds `to_{be, le, ne}_bytes` methods to `SimulatorDisplay`. I'm using this feature in the new font conversion tool, which uses a `SimulatorDisplay` to draw the image of the glyphs. This image can then be exported to PNG and RAW files. IMO this feature could also be useful for other applications that need to generate data for use with `RawImage`.

I've also changed the PNG compression to `Best`. This can significantly reduce the size of the generated PNG files, which also reduces the size of the inlined images in the docs.