### PR TITLE
Add checking feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#28](https://github.com/embedded-graphics/simulator/pull/28) Added `SimulatorDisplay::to_{be,le,ne}_bytes` to convert the display content to raw image data.
 - [#29](https://github.com/embedded-graphics/simulator/pull/29) Added support for `EG_SIMULATOR_CHECK`, `EG_SIMULATOR_CHECK_RAW` and `EG_SIMULATOR_DUMP_RAW` environment variables.
+- [#29](https://github.com/embedded-graphics/simulator/pull/29) A limited version of `Window` can now be used without the `with-sdl` feature enabled. Event handling isn't available if SDL support is disabled.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 ### Added
 
 - [#28](https://github.com/embedded-graphics/simulator/pull/28) Added `SimulatorDisplay::to_{be,le,ne}_bytes` to convert the display content to raw image data.
+- [#29](https://github.com/embedded-graphics/simulator/pull/29) Added support for `EG_SIMULATOR_CHECK`, `EG_SIMULATOR_CHECK_RAW` and `EG_SIMULATOR_DUMP_RAW` environment variables.
+
+### Changed
+
+- **(breaking**) [#29](https://github.com/embedded-graphics/simulator/pull/29) Color types used in `Window::update`and `Window::show_static` must now implement `From<Rgb888>`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ways to get it working, but probably the simplest method is copying the binaries
 ## Creating screenshots
 
 Screenshots of programs, that use `Window` to display a simulated display, can be created by
-setting the `EG_SIMULATOR_DUMP` environment variable:
+setting the `EG_SIMULATOR_DUMP` or `EG_SIMULATOR_DUMP_RAW` environment variable:
 
 ```bash
 EG_SIMULATOR_DUMP=screenshot.png cargo run
@@ -98,12 +98,30 @@ EG_SIMULATOR_DUMP=screenshot.png cargo run
 By setting the variable the display passed to the first `Window::update` call gets exported as a
 PNG file to the specified path. After the file is exported the process is terminated.
 
+The difference between `EG_SIMULATOR_DUMP` and `EG_SIMULATOR_DUMP_RAW` is that the first method
+applies the output settings before exporting the PNG file and the later dumps the unaltered
+display content.
+
 ## Exporting images
 
 If a program doesn't require to display a window and only needs to export one or more images, a
 `SimulatorDisplay` can also be converted to an `image` crate `ImageBuffer` by using the
 `to_image_buffer` method. The resulting buffer can then be used to save the display content to
 any format supported by `image`.
+
+## Using the simulator in CI
+
+The simulator supports two environment variables to check if the display content matches a
+reference PNG file: `EG_SIMULATOR_CHECK` and `EG_SIMULATOR_CHECK_RAW`. If the display content
+of the first `Window::update` call doesn't match the reference image the process exits with a
+non zero exit exit code. Otherwise the process will exit with a zero exit code.
+
+```bash
+EG_SIMULATOR_CHECK=screenshot.png cargo run || echo "Display doesn't match PNG file"
+```
+
+`EG_SIMULATOR_CHECK` assumes that the reference image was created using the same
+`OutputSetting`s, while `EG_SIMULATOR_CHECK_RAW` assumes an unstyled reference image.
 
 ## Usage without SDL2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! # Creating screenshots
 //!
 //! Screenshots of programs, that use `Window` to display a simulated display, can be created by
-//! setting the `EG_SIMULATOR_DUMP` environment variable:
+//! setting the `EG_SIMULATOR_DUMP` or `EG_SIMULATOR_DUMP_RAW` environment variable:
 //!
 //! ```bash
 //! EG_SIMULATOR_DUMP=screenshot.png cargo run
@@ -89,12 +89,30 @@
 //! By setting the variable the display passed to the first `Window::update` call gets exported as a
 //! PNG file to the specified path. After the file is exported the process is terminated.
 //!
+//! The difference between `EG_SIMULATOR_DUMP` and `EG_SIMULATOR_DUMP_RAW` is that the first method
+//! applies the output settings before exporting the PNG file and the later dumps the unaltered
+//! display content.
+//!
 //! # Exporting images
 //!
 //! If a program doesn't require to display a window and only needs to export one or more images, a
 //! `SimulatorDisplay` can also be converted to an `image` crate `ImageBuffer` by using the
 //! `to_image_buffer` method. The resulting buffer can then be used to save the display content to
 //! any format supported by `image`.
+//!
+//! # Using the simulator in CI
+//!
+//! The simulator supports two environment variables to check if the display content matches a
+//! reference PNG file: `EG_SIMULATOR_CHECK` and `EG_SIMULATOR_CHECK_RAW`. If the display content
+//! of the first `Window::update` call doesn't match the reference image the process exits with a
+//! non zero exit exit code. Otherwise the process will exit with a zero exit code.
+//!
+//! ```bash
+//! EG_SIMULATOR_CHECK=screenshot.png cargo run || echo "Display doesn't match PNG file"
+//! ```
+//!
+//! `EG_SIMULATOR_CHECK` assumes that the reference image was created using the same
+//! `OutputSetting`s, while `EG_SIMULATOR_CHECK_RAW` assumes an unstyled reference image.
 //!
 //! # Usage without SDL2
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,12 +138,10 @@ mod display;
 mod output_image;
 mod output_settings;
 mod theme;
-
-#[cfg(feature = "with-sdl")]
 mod window;
 
 #[cfg(feature = "with-sdl")]
-pub use window::{SimulatorEvent, Window};
+pub use window::SimulatorEvent;
 
 /// Re-exported types from sdl2 crate.
 ///
@@ -164,4 +162,5 @@ pub use crate::{
     output_image::OutputImage,
     output_settings::{OutputSettings, OutputSettingsBuilder},
     theme::BinaryColorTheme,
+    window::Window,
 };

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, ops::Deref};
 
 #[cfg(feature = "with-sdl")]
 use std::{thread, time::Duration};
@@ -116,7 +116,10 @@ impl Window {
             );
 
             assert!(
-                output.as_image_buffer().as_raw().eq(&expected.as_raw()),
+                output
+                    .as_image_buffer()
+                    .as_raw()
+                    .eq(&expected.as_raw().deref()),
                 "display content doesn't match PNG file",
             );
 


### PR DESCRIPTION
This PR adds support for checking the content of a `Window` against a reference image. We can use this to check the examples in CI and it can also be useful for more complex tests, where a PNG file is easier to use than a `MockDisplay` pattern.

The PR also makes it possible to use `Window` without SDL support enabled, which makes it easier to test static examples in CI.

@bugadani Thanks for inspiring this PR with the e-t CI config.