### PR TITLE
Update to e-g 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,11 @@ circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 [dependencies]
 image = "0.23.0"
 base64 = "0.13.0"
+embedded-graphics = "0.7.0"
 
 [dependencies.sdl2]
 version = "0.32.2"
 optional = true
-
-[dependencies.embedded-graphics]
-version = "0.7.0-beta.1"
 
 [features]
 default = [ "with-sdl" ]


### PR DESCRIPTION
This PR updates the e-g dependency to 0.7.0.