### PR TITLE
Specify a stricter core version dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 image = "0.23.0"
 base64 = "0.13.0"
 embedded-graphics = "0.7.0"
+embedded-graphics-core = "0.3.2"
 
 [dependencies.sdl2]
 version = "0.32.2"


### PR DESCRIPTION
e-g only requires minimum core version "0.3.0", while simulator actually depends on changes made in "0.3.2". This PR adds the version requirement so that maybe in the future we can avoid a slightly annoying case of "hey, stable versions don't compile because one of the dependencies didn't get updated".

Thank you for helping out with embedded-graphics-simulator development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add an example where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

[add your PR description here]
