### PR TITLE
Support multiple windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,14 @@ base64 = "0.13.0"
 embedded-graphics = "0.7.1"
 
 [dependencies.sdl2]
-version = "0.32.2"
+version = "0.35.1"
+optional = true
+
+[dependencies.once_cell]
+version = "1.8.0"
 optional = true
 
 [features]
 default = [ "with-sdl" ]
 fixed_point = [ "embedded-graphics/fixed_point" ]
-with-sdl = [ "sdl2" ]
+with-sdl = [ "sdl2", "once_cell" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 [dependencies]
 image = "0.23.0"
 base64 = "0.13.0"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8"
 
 [dependencies.sdl2]
 version = "0.35.1"

--- a/src/window.rs
+++ b/src/window.rs
@@ -287,78 +287,83 @@ impl SdlWindow {
         output_settings: &OutputSettings,
     ) -> impl Iterator<Item = SimulatorEvent> + '_ {
         let output_settings = output_settings.clone();
-        SDL.with(|sdl| sdl.borrow_mut().event_pump.poll_iter().collect::<Vec<Event>>())
-           .into_iter()
-           .filter_map(move |event| match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
-                    keycode: Some(Keycode::Escape),
-                    ..
-                } => Some(SimulatorEvent::Quit),
-                Event::KeyDown {
-                    keycode,
-                    keymod,
-                    repeat,
-                    ..
-                } => {
-                    if let Some(valid_keycode) = keycode {
-                        Some(SimulatorEvent::KeyDown {
-                            keycode: valid_keycode,
-                            keymod,
-                            repeat,
-                        })
-                    } else {
-                        None
-                    }
-                }
-                Event::KeyUp {
-                    keycode,
-                    keymod,
-                    repeat,
-                    ..
-                } => {
-                    if let Some(valid_keycode) = keycode {
-                        Some(SimulatorEvent::KeyUp {
-                            keycode: valid_keycode,
-                            keymod,
-                            repeat,
-                        })
-                    } else {
-                        None
-                    }
-                }
-                Event::MouseButtonUp {
-                    x, y, mouse_btn, ..
-                } if event.get_window_id() == Some(self.canvas.window().id()) => {
-                    match event.get_window_id() {
-                        Some(id) if id == self.canvas.window().id() => {
-                            let point = output_settings.output_to_display(Point::new(x, y));
-                            Some(SimulatorEvent::MouseButtonUp { point, mouse_btn })
-                        },
-                        _ => None,
-                    }
-                }
-                Event::MouseButtonDown {
-                    x, y, mouse_btn, ..
-                } if event.get_window_id() == Some(self.canvas.window().id()) => {
-                    let point = output_settings.output_to_display(Point::new(x, y));
-                    Some(SimulatorEvent::MouseButtonDown { point, mouse_btn })
-                }
-                Event::MouseWheel {
-                    x, y, direction, ..
-                } if event.get_window_id() == Some(self.canvas.window().id()) => {
-                    Some(SimulatorEvent::MouseWheel {
-                        scroll_delta: Point::new(x, y),
-                        direction,
+        SDL.with(|sdl| {
+            sdl.borrow_mut()
+                .event_pump
+                .poll_iter()
+                .collect::<Vec<Event>>()
+        })
+        .into_iter()
+        .filter_map(move |event| match event {
+            Event::Quit { .. }
+            | Event::KeyDown {
+                keycode: Some(Keycode::Escape),
+                ..
+            } => Some(SimulatorEvent::Quit),
+            Event::KeyDown {
+                keycode,
+                keymod,
+                repeat,
+                ..
+            } => {
+                if let Some(valid_keycode) = keycode {
+                    Some(SimulatorEvent::KeyDown {
+                        keycode: valid_keycode,
+                        keymod,
+                        repeat,
                     })
+                } else {
+                    None
                 }
-                Event::MouseMotion {
-                    x, y, .. 
-                } if event.get_window_id() == Some(self.canvas.window().id()) => {
-                    let point = output_settings.output_to_display(Point::new(x, y));
-                    Some(SimulatorEvent::MouseMove { point })
+            }
+            Event::KeyUp {
+                keycode,
+                keymod,
+                repeat,
+                ..
+            } => {
+                if let Some(valid_keycode) = keycode {
+                    Some(SimulatorEvent::KeyUp {
+                        keycode: valid_keycode,
+                        keymod,
+                        repeat,
+                    })
+                } else {
+                    None
                 }
-                _ => None,
-            })
+            }
+            Event::MouseButtonUp {
+                x, y, mouse_btn, ..
+            } if event.get_window_id() == Some(self.canvas.window().id()) => {
+                match event.get_window_id() {
+                    Some(id) if id == self.canvas.window().id() => {
+                        let point = output_settings.output_to_display(Point::new(x, y));
+                        Some(SimulatorEvent::MouseButtonUp { point, mouse_btn })
+                    }
+                    _ => None,
+                }
+            }
+            Event::MouseButtonDown {
+                x, y, mouse_btn, ..
+            } if event.get_window_id() == Some(self.canvas.window().id()) => {
+                let point = output_settings.output_to_display(Point::new(x, y));
+                Some(SimulatorEvent::MouseButtonDown { point, mouse_btn })
+            }
+            Event::MouseWheel {
+                x, y, direction, ..
+            } if event.get_window_id() == Some(self.canvas.window().id()) => {
+                Some(SimulatorEvent::MouseWheel {
+                    scroll_delta: Point::new(x, y),
+                    direction,
+                })
+            }
+            Event::MouseMotion { x, y, .. }
+                if event.get_window_id() == Some(self.canvas.window().id()) =>
+            {
+                let point = output_settings.output_to_display(Point::new(x, y));
+                Some(SimulatorEvent::MouseMove { point })
+            }
+            _ => None,
+        })
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -329,23 +329,32 @@ impl SdlWindow {
                 }
                 Event::MouseButtonUp {
                     x, y, mouse_btn, ..
-                } => {
-                    let point = output_settings.output_to_display(Point::new(x, y));
-                    Some(SimulatorEvent::MouseButtonUp { point, mouse_btn })
+                } if event.get_window_id() == Some(self.canvas.window().id()) => {
+                    match event.get_window_id() {
+                        Some(id) if id == self.canvas.window().id() => {
+                            let point = output_settings.output_to_display(Point::new(x, y));
+                            Some(SimulatorEvent::MouseButtonUp { point, mouse_btn })
+                        },
+                        _ => None,
+                    }
                 }
                 Event::MouseButtonDown {
                     x, y, mouse_btn, ..
-                } => {
+                } if event.get_window_id() == Some(self.canvas.window().id()) => {
                     let point = output_settings.output_to_display(Point::new(x, y));
                     Some(SimulatorEvent::MouseButtonDown { point, mouse_btn })
                 }
                 Event::MouseWheel {
                     x, y, direction, ..
-                } => Some(SimulatorEvent::MouseWheel {
-                    scroll_delta: Point::new(x, y),
-                    direction,
-                }),
-                Event::MouseMotion { x, y, .. } => {
+                } if event.get_window_id() == Some(self.canvas.window().id()) => {
+                    Some(SimulatorEvent::MouseWheel {
+                        scroll_delta: Point::new(x, y),
+                        direction,
+                    })
+                }
+                Event::MouseMotion {
+                    x, y, .. 
+                } if event.get_window_id() == Some(self.canvas.window().id()) => {
                     let point = output_settings.output_to_display(Point::new(x, y));
                     Some(SimulatorEvent::MouseMove { point })
                 }


### PR DESCRIPTION
I needed multiple windows support for simulating my embedded-graphics project, and this was the cleanest way I could think of to make it work without changing the current API. Basically, the SDL context is created once in Lazy cell from `once_cell`, which is then stored in a thread-local static RefCell, from where it can be used by the windows as required. Previously it was created when a `Window` was made and stored in the `Window`, which panics if done twice.

From the user's point of view, nothing is different with a single `Window`, but now instead of a panic if you create a second `Window`, it just works and is created as expected.

Most of the change is around event handling: because all events are shared by all windows, it doesn't make a difference which `Window` you poll for events. The underlying SDL events have a "window ID" which you can match against an SDL window ID to know where they came from, but the current embedded-graphics-simulator API doesn't expose this. Instead, I have all keyboard events appear no matter which `Window` you poll,  and only mouse events related to the `Window` being polled are returned. This means mouse events on another `Window` are completely lost, and the end-user's code should pick a single `Window` to poll. 

This seemed like a good trade-off but it does mean you can't handle multiple windows where both of them need mouse-like events -- I think that would need a slightly different API or something cleverer under-the-hood to poll SDL events and distribute them out to each `Window`. Still, for projects where zero or only one window needs mouse events, at least with these changes it's easy to have two windows.

I'm more or less submitting this just where I got to with it, but i'm happy to add some more documentation or changelog entries if you'd like!