### PR TITLE
Add note on setting LIBRARY_PATH for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ sudo apt install libsdl2-dev
 brew install sdl2
 ```
 
+Users on Apple silicon or with custom installation directories will need to
+set `LIBRARY_PATH` for the linker to find the installed SDL2 package:
+
+```bash
+export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+```
+More information can be found in the
+[SDL2 documentation](https://github.com/Rust-SDL2/rust-sdl2#homebrew).
+
 ### Windows
 
 The Windows install process is a bit more involved, but it _does_ work. See [the Rust-SDL2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,15 @@
 //! brew install sdl2
 //! ```
 //!
+//! Users on Apple silicon or with custom installation directories will need to
+//! set `LIBRARY_PATH` for the linker to find the installed SDL2 package:
+//!
+//! ```bash
+//! export LIBRARY_PATH="$LIBRARY_PATH:$(brew --prefix)/lib"
+//! ```
+//! More information can be found in the
+//! [SDL2 documentation](https://github.com/Rust-SDL2/rust-sdl2#homebrew).
+//!
 //! ## Windows
 //!
 //! The Windows install process is a bit more involved, but it _does_ work. See [the Rust-SDL2


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add an example where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR adds a note on setting `LIBRARY_PATH` for newer Homebrew installations with do not install or link their libraries in `/usr/local/lib`. For example, on M1 machines, Homebrew gets installed to `/opt/homebrew` and therefor libs reside in `/opt/homebrew/lib`.

This is stated in the documentation of the `sdl2` crate. But it took me some minutes to figure this out for myself.
