### PR TITLE
Update to Rust edition 2021

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Check that everything (tests, benches, etc) builds in std environments
 precheck_steps: &precheck_steps
   docker:
-    - image: jamwaffles/circleci-embedded-graphics:1.40.0-3
+    - image: jamwaffles/circleci-embedded-graphics:1.57.0-0
       auth:
         username: jamwaffles
         password: $DOCKERHUB_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
 - [#34](https://github.com/embedded-graphics/simulator/pull/34) Bump minimum embedded-graphics version from 0.7.0 to 0.7.1.
+- **(breaking)** [#39](https://github.com/embedded-graphics/simulator/pull/39) Bump Minimum Supported Rust Version (MSRV) to 1.57.
 
 ## [0.3.0] - 2021-06-05
 
@@ -22,7 +25,7 @@
 
 ### Changed
 
-- **(breaking**) [#29](https://github.com/embedded-graphics/simulator/pull/29) Color types used in `Window::update`and `Window::show_static` must now implement `From<Rgb888>`.
+- **(breaking)** [#29](https://github.com/embedded-graphics/simulator/pull/29) Color types used in `Window::update`and `Window::show_static` must now implement `From<Rgb888>`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["embedded", "no-std"]
 keywords = ["embedded-graphics", "simulator", "graphics", "embedded"]
 readme = "./README.md"
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 exclude = [
     "/.circleci/",
     "/.github/",
@@ -20,12 +20,12 @@ exclude = [
 circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 
 [dependencies]
-image = "0.23.0"
+image = "0.23.14"
 base64 = "0.13.0"
 embedded-graphics = "0.7.1"
 
 [dependencies.sdl2]
-version = "0.32.2"
+version = "0.35.1"
 optional = true
 
 [features]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ See the [Choosing
 Features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)
 Cargo manifest documentation for more details.
 
+## Minimum supported Rust version
+
+The minimum supported Rust version for embedded-graphics is `1.57` or greater.
+Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Cargo manifest documentation for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics is `1.57` or greater.
+The minimum supported Rust version for embedded-graphics-simulator is `1.57` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## License

--- a/README.tpl
+++ b/README.tpl
@@ -9,6 +9,11 @@
 
 {{readme}}
 
+## Minimum supported Rust version
+
+The minimum supported Rust version for embedded-graphics is `1.57` or greater.
+Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
+
 ## License
 
 Licensed under either of

--- a/README.tpl
+++ b/README.tpl
@@ -11,7 +11,7 @@
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics is `1.57` or greater.
+The minimum supported Rust version for embedded-graphics-simulator is `1.57` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## License


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [ ] Check that you've added passing tests and documentation
- [ ] Add an example where applicable
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [ ] Run `rustfmt` on the project
- [ ] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

This PR updates to Rust edition 2021 and the MSRV to 1.57.0.
