### PR TITLE
Migrate to intra-doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ setting the `EG_SIMULATOR_DUMP` or `EG_SIMULATOR_DUMP_RAW` environment variable:
 EG_SIMULATOR_DUMP=screenshot.png cargo run
 ```
 
-By setting the variable the display passed to the first `Window::update` call gets exported as a
-PNG file to the specified path. After the file is exported the process is terminated.
+By setting the variable the display passed to the first `Window::update` call gets exported as
+a PNG file to the specified path. After the file is exported the process is terminated.
 
 The difference between `EG_SIMULATOR_DUMP` and `EG_SIMULATOR_DUMP_RAW` is that the first method
 applies the output settings before exporting the PNG file and the later dumps the unaltered
@@ -105,9 +105,12 @@ display content.
 ## Exporting images
 
 If a program doesn't require to display a window and only needs to export one or more images, a
-`SimulatorDisplay` can also be converted to an `image` crate `ImageBuffer` by using the
-`to_image_buffer` method. The resulting buffer can then be used to save the display content to
-any format supported by `image`.
+`SimulatorDisplay` can also be converted to an `image` crate
+[`ImageBuffer`](image::ImageBuffer) by using the
+[`to_rgb_output_image`](SimulatorDisplay::to_rgb_output_image) or
+[`to_grayscale_output_image`](SimulatorDisplay::to_grayscale_output_image) methods
+The resulting buffer can then be used to save the display content to any format supported by
+`image`.
 
 ## Using the simulator in CI
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ display content.
 
 If a program doesn't require to display a window and only needs to export one or more images, a
 `SimulatorDisplay` can also be converted to an `image` crate
-[`ImageBuffer`](image::ImageBuffer) by using the
-[`to_rgb_output_image`](SimulatorDisplay::to_rgb_output_image) or
-[`to_grayscale_output_image`](SimulatorDisplay::to_grayscale_output_image) methods
+`ImageBuffer` by using the `to_rgb_output_image` or `to_grayscale_output_image` methods.
 The resulting buffer can then be used to save the display content to any format supported by
 `image`.
 
@@ -143,6 +141,7 @@ default-features = false
 See the [Choosing
 Features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)
 Cargo manifest documentation for more details.
+
 
 ## Minimum supported Rust version
 

--- a/filter_readme.sed
+++ b/filter_readme.sed
@@ -3,6 +3,9 @@
 # Remove footer-reference-style doc links like "[`Foo`]: ./foo/trait.Foo.html"
 /\[.+\]: .*(struct|enum|trait|type|fn|index)\./d
 
+# Remove intra-doc links like "[`Foo`]: foo::Foo"
+/\[.+\]: .*::/d
+
 # Remove inline-style doc links like "[`Foo`](./foo/trait.Foo.html)",
 # leaving just "`Foo`" in its place
 s/\[(.+)\]\(.*(struct|enum|trait|type|fn|index).*\)/\1/g

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ check-formatting:
 # Generates the docs
 generate-docs:
     cargo clean --doc
-    RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features
+    cargo doc --all-features
 
 # Runs cargo-deadlinks on the docs
 check-links: generate-docs

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ target_dir := "target"
 # Building
 #----------
 
-build: check-formatting test test-all build-simulator check-readme check-links
+build: check-formatting test test-all build-simulator check-readme generate-docs
 
 # Build the simulator
 build-simulator:
@@ -29,7 +29,7 @@ check-formatting:
 # Generates the docs
 generate-docs:
     cargo clean --doc
-    cargo doc --all-features
+    RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features
 
 # Runs cargo-deadlinks on the docs
 check-links: generate-docs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,15 +79,15 @@
 //!
 //! # Creating screenshots
 //!
-//! Screenshots of programs, that use `Window` to display a simulated display, can be created by
+//! Screenshots of programs, that use [`Window`] to display a simulated display, can be created by
 //! setting the `EG_SIMULATOR_DUMP` or `EG_SIMULATOR_DUMP_RAW` environment variable:
 //!
 //! ```bash
 //! EG_SIMULATOR_DUMP=screenshot.png cargo run
 //! ```
 //!
-//! By setting the variable the display passed to the first `Window::update` call gets exported as a
-//! PNG file to the specified path. After the file is exported the process is terminated.
+//! By setting the variable the display passed to the first [`Window::update`] call gets exported as
+//! a PNG file to the specified path. After the file is exported the process is terminated.
 //!
 //! The difference between `EG_SIMULATOR_DUMP` and `EG_SIMULATOR_DUMP_RAW` is that the first method
 //! applies the output settings before exporting the PNG file and the later dumps the unaltered
@@ -96,15 +96,18 @@
 //! # Exporting images
 //!
 //! If a program doesn't require to display a window and only needs to export one or more images, a
-//! `SimulatorDisplay` can also be converted to an `image` crate `ImageBuffer` by using the
-//! `to_image_buffer` method. The resulting buffer can then be used to save the display content to
-//! any format supported by `image`.
+//! [`SimulatorDisplay`] can also be converted to an [`image`] crate
+//! [`ImageBuffer`](image::ImageBuffer) by using the
+//! [`to_rgb_output_image`](SimulatorDisplay::to_rgb_output_image) or
+//! [`to_grayscale_output_image`](SimulatorDisplay::to_grayscale_output_image) methods
+//! The resulting buffer can then be used to save the display content to any format supported by
+//! [`image`].
 //!
 //! # Using the simulator in CI
 //!
 //! The simulator supports two environment variables to check if the display content matches a
 //! reference PNG file: `EG_SIMULATOR_CHECK` and `EG_SIMULATOR_CHECK_RAW`. If the display content
-//! of the first `Window::update` call doesn't match the reference image the process exits with a
+//! of the first [`Window::update`] call doesn't match the reference image the process exits with a
 //! non zero exit exit code. Otherwise the process will exit with a zero exit code.
 //!
 //! ```bash
@@ -147,8 +150,6 @@ pub use window::SimulatorEvent;
 ///
 /// The types in this module are used in the [`SimulatorEvent`] enum and are re-exported from the
 /// `sdl2` crate to make it possible to use them without adding a dependency to `sdl2`.
-///
-/// [`SimulatorEvent`]: ../enum.SimulatorEvent.html
 #[cfg(feature = "with-sdl")]
 pub mod sdl2 {
     pub use sdl2::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,7 @@
 //!
 //! If a program doesn't require to display a window and only needs to export one or more images, a
 //! [`SimulatorDisplay`] can also be converted to an [`image`] crate
-//! [`ImageBuffer`](image::ImageBuffer) by using the
-//! [`to_rgb_output_image`](SimulatorDisplay::to_rgb_output_image) or
-//! [`to_grayscale_output_image`](SimulatorDisplay::to_grayscale_output_image) methods
+//! [`ImageBuffer`] by using the [`to_rgb_output_image`] or [`to_grayscale_output_image`] methods.
 //! The resulting buffer can then be used to save the display content to any format supported by
 //! [`image`].
 //!
@@ -134,6 +132,10 @@
 //! See the [Choosing
 //! Features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)
 //! Cargo manifest documentation for more details.
+//!
+//! [`ImageBuffer`]: image::ImageBuffer
+//! [`to_rgb_output_image`]: SimulatorDisplay::to_rgb_output_image
+//! [`to_grayscale_output_image`]: SimulatorDisplay::to_grayscale_output_image
 
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,11 @@
 //! [`to_rgb_output_image`]: SimulatorDisplay::to_rgb_output_image
 //! [`to_grayscale_output_image`]: SimulatorDisplay::to_grayscale_output_image
 
-#![deny(missing_docs)]
+#![deny(
+    missing_docs,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links
+)]
 
 mod display;
 mod output_image;

--- a/src/output_image.rs
+++ b/src/output_image.rs
@@ -17,8 +17,6 @@ use crate::{display::SimulatorDisplay, output_settings::OutputSettings};
 /// An output image is the result of applying [`OutputSettings`] to a [`SimulatorDisplay`]. It can
 /// be used to save a simulator display to a PNG file.
 ///
-/// [`OutputSettings`]: struct.OutputSettings.html
-/// [`SimulatorDisplay`]: struct.SimulatorDisplay.html
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct OutputImage<C> {
     size: Size,
@@ -61,7 +59,7 @@ where
         }
     }
 
-    /// Updates the image from a `SimulatorDisplay`.
+    /// Updates the image from a [`SimulatorDisplay`].
     pub fn update<DisplayC>(&mut self, display: &SimulatorDisplay<DisplayC>)
     where
         DisplayC: PixelColor + Into<Rgb888>,
@@ -118,7 +116,7 @@ impl<C: OutputImageColor> OutputImage<C> {
         Ok(png)
     }
 
-    /// Returns the output image as an `image` crate `ImageBuffer`.
+    /// Returns the output image as an [`image`] crate [`ImageBuffer`].
     pub fn as_image_buffer(&self) -> ImageBuffer<C::ImageColor, &[u8]> {
         ImageBuffer::from_raw(self.size.width, self.size.height, self.data.as_ref()).unwrap()
     }

--- a/src/output_settings.rs
+++ b/src/output_settings.rs
@@ -92,7 +92,6 @@ impl OutputSettingsBuilder {
     /// Note that a theme should only be set when an monochrome display is used.
     /// Setting a theme when using a color display will cause an corrupted output.
     ///
-    /// [`BinaryColorTheme`]: enum.BinaryColorTheme.html
     pub fn theme(mut self, theme: BinaryColorTheme) -> Self {
         self.theme = theme;
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -17,7 +17,7 @@ use crate::{
     display::SimulatorDisplay, output_image::OutputImage, output_settings::OutputSettings,
 };
 
-/// A derivation of sdl2::event::Event mapped to embedded-graphics coordinates
+/// A derivation of [`sdl2::event::Event`] mapped to embedded-graphics coordinates
 #[cfg(feature = "with-sdl")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SimulatorEvent {
@@ -203,7 +203,7 @@ impl Window {
     ///
     /// # Panics
     ///
-    /// Panics if called before `update` is called at least once.
+    /// Panics if called before [`update`](Self::update) is called at least once.
     #[cfg(feature = "with-sdl")]
     pub fn events(&mut self) -> impl Iterator<Item = SimulatorEvent> + '_ {
         self.sdl_window


### PR DESCRIPTION
This PR changes the doc links to intra-doc links and uses rustdoc instead of checklinks to check the links in CI.

I just noticed that the README generation still needs some work to remove the intra-doc links.