### PR TITLE
Update ouroboros following RUSTSEC-2023-0042

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 precheck_steps: &precheck_steps
   resource_class: large
   docker:
-    - image: jamwaffles/circleci-embedded-graphics:1.61.0-0
+    - image: jamwaffles/circleci-embedded-graphics:1.71.1-0
       auth:
         username: jamwaffles
         password: $DOCKERHUB_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- **(breaking)** [#49](https://github.com/embedded-graphics/simulator/pull/49) Bump Minimum Supported Rust Version (MSRV) to 1.71.1.
+
 ## [0.5.0] - 2023-05-14
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ image = "0.23.14"
 base64 = "0.13.0"
 embedded-graphics = "0.8.0"
 sdl2 = { version = "0.35.1", optional = true }
-ouroboros = { version = "0.15.5", optional = true }
+ouroboros = { version = "0.17.2", optional = true }
 
 [features]
 default = ["with-sdl"]

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Cargo manifest documentation for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics-simulator is `1.61` or greater.
+The minimum supported Rust version for embedded-graphics-simulator is `1.71.1` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## License

--- a/README.tpl
+++ b/README.tpl
@@ -11,7 +11,7 @@
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version for embedded-graphics-simulator is `1.61` or greater.
+The minimum supported Rust version for embedded-graphics-simulator is `1.71.1` or greater.
 Ensure you have the correct version of Rust installed, preferably through <https://rustup.rs>.
 
 ## License


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add an example where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Quick update to `ouroboros` `0.15.5` -> `0.17.2` (latest). [RUSTSEC_2023-0042](https://rustsec.org/advisories/RUSTSEC-2023-0042) has flagged versions `<0.16.0` as unsound.

I can update the other dependencies if you think it's worth doing as part of this PR.
I quickly scanned the CHANGELOG and it doesn't seem like you mark dependency updates (other than `embedded-graphics`) so I did not add this change to the log.

### (edit) Rust MSRV

It looks CI is failing because `half v2.3.1` requires Rust version `>= v1.70.0`. Seeing as `jamwaffles` provides the `circleci-embedded-graphics` container with rust version 1.71.1, I've bumped the MSRV to that.