### PR TITLE
Remove dev-version from release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-dev-version = false
 pre-release-replacements = [
   {file="CHANGELOG.md", prerelease=true, search="[Uu]nreleased", replace="{{version}}"},
   {file="CHANGELOG.md", prerelease=true, search="\\.\\.\\.HEAD", replace="...{{tag_name}}"},


### PR DESCRIPTION
Newer versions of cargo-release no longer support `dev-version`.