### PR TITLE
Release embedded-graphics-simulator 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+## [0.6.0] - 2023-11-26
+
 - **(breaking)** [#49](https://github.com/embedded-graphics/simulator/pull/49) Bump Minimum Supported Rust Version (MSRV) to 1.71.1.
 - **(breaking)** [#52](https://github.com/embedded-graphics/simulator/pull/52) Bump `image` crate dependency to 0.24.7.
 
@@ -123,7 +125,8 @@
 - The builtin simulator now supports colour pixel types, like `RGB565`.
 
 <!-- next-url -->
-[unreleased]: https://github.com/embedded-graphics/embedded-graphics-simulator/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/embedded-graphics/embedded-graphics-simulator/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/embedded-graphics/embedded-graphics-simulator/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/embedded-graphics/embedded-graphics-simulator/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/embedded-graphics/embedded-graphics-simulator/compare/v0.4.0...v0.4.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.5.0"
+version = "0.6.0"
 name = "embedded-graphics-simulator"
 description = "Embedded graphics simulator"
 authors = ["James Waples <james@wapl.es>", "Ralf Fuest <mail@rfuest.de>"]


### PR DESCRIPTION
`cargo-relase` still wasn't able to create the commit for the new version automatically.