### PR TITLE
Update dependencies: image, base64, sdl2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- **(breaking)** [#55](https://github.com/embedded-graphics/simulator/pull/55) Bump the following crate dependencies: `image` to 0.25.1, `base64` to 0.22.1, `sdl2` to 0.37.0
+
 ## [0.6.0] - 2023-11-26
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ exclude = [
 circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 
 [dependencies]
-image = "0.24.7"
-base64 = "0.21.5"
+image = "0.25.1"
+base64 = "0.22.1"
 embedded-graphics = "0.8.1"
-sdl2 = { version = "0.35.2", optional = true }
+sdl2 = { version = "0.37.0", optional = true }
 ouroboros = { version = "0.18.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 
 [dependencies]
-image = "0.25.1"
+image = { version = "0.25.1", default-features=false, features=["png"] }
 base64 = "0.22.1"
 embedded-graphics = "0.8.1"
 sdl2 = { version = "0.37.0", optional = true }

--- a/src/display.rs
+++ b/src/display.rs
@@ -187,7 +187,7 @@ where
 
         if C::Raw::BITS_PER_PIXEL >= 8 {
             for pixel in self.pixels.iter() {
-                bytes.extend_from_slice(&pixel_to_bytes(*pixel).as_ref())
+                bytes.extend_from_slice(pixel_to_bytes(*pixel).as_ref())
             }
         } else {
             let pixels_per_byte = 8 / C::Raw::BITS_PER_PIXEL;

--- a/src/output_image.rs
+++ b/src/output_image.rs
@@ -111,7 +111,7 @@ impl<C: OutputImageColor> OutputImage<C> {
                 self.data.as_ref(),
                 self.size.width,
                 self.size.height,
-                C::IMAGE_COLOR_TYPE,
+                C::IMAGE_COLOR_TYPE.into(),
             )?;
 
         Ok(png)

--- a/src/output_image.rs
+++ b/src/output_image.rs
@@ -91,7 +91,7 @@ impl<C: OutputImageColor> OutputImage<C> {
     pub fn save_png<PATH: AsRef<Path>>(&self, path: PATH) -> image::ImageResult<()> {
         let png = self.encode_png()?;
 
-        std::fs::write(path, &png)?;
+        std::fs::write(path, png)?;
 
         Ok(())
     }
@@ -100,7 +100,7 @@ impl<C: OutputImageColor> OutputImage<C> {
     pub fn to_base64_png(&self) -> image::ImageResult<String> {
         let png = self.encode_png()?;
 
-        Ok(base64::engine::general_purpose::STANDARD.encode(&png))
+        Ok(base64::engine::general_purpose::STANDARD.encode(png))
     }
 
     fn encode_png(&self) -> image::ImageResult<Vec<u8>> {

--- a/src/output_settings.rs
+++ b/src/output_settings.rs
@@ -49,6 +49,7 @@ impl Default for OutputSettings {
 }
 
 /// Output settings builder.
+#[derive(Default)]
 pub struct OutputSettingsBuilder {
     scale: Option<u32>,
     pixel_spacing: Option<u32>,
@@ -59,12 +60,7 @@ pub struct OutputSettingsBuilder {
 impl OutputSettingsBuilder {
     /// Creates new output settings builder.
     pub fn new() -> Self {
-        Self {
-            scale: None,
-            pixel_spacing: None,
-            theme: BinaryColorTheme::Default,
-            max_fps: None,
-        }
+        Self::default()
     }
 
     /// Sets the pixel scale.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,9 +1,10 @@
 use embedded_graphics::pixelcolor::{Rgb888, RgbColor};
 
 /// Color theme for binary displays
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum BinaryColorTheme {
     /// A simple on/off, non-styled display with black background and white pixels
+    #[default]
     Default,
 
     /// Inverted colors.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -130,7 +130,7 @@ impl Window {
             let sdl_window = self.sdl_window.as_mut().unwrap();
 
             framebuffer.update(display);
-            sdl_window.update(&framebuffer);
+            sdl_window.update(framebuffer);
         }
 
         thread::sleep(
@@ -149,7 +149,7 @@ impl Window {
     where
         C: PixelColor + Into<Rgb888> + From<Rgb888>,
     {
-        self.update(&display);
+        self.update(display);
 
         #[cfg(feature = "with-sdl")]
         'running: loop {

--- a/src/window/sdl_window.rs
+++ b/src/window/sdl_window.rs
@@ -126,7 +126,7 @@ impl SdlWindow {
         });
 
         self.canvas
-            .copy(&self.window_texture.borrow_texture(), None, None)
+            .copy(self.window_texture.borrow_texture(), None, None)
             .unwrap();
         self.canvas.present();
     }
@@ -151,33 +151,21 @@ impl SdlWindow {
                     keymod,
                     repeat,
                     ..
-                } => {
-                    if let Some(valid_keycode) = keycode {
-                        Some(SimulatorEvent::KeyDown {
-                            keycode: valid_keycode,
-                            keymod,
-                            repeat,
-                        })
-                    } else {
-                        None
-                    }
-                }
+                } => keycode.map(|valid_keycode| SimulatorEvent::KeyDown {
+                    keycode: valid_keycode,
+                    keymod,
+                    repeat,
+                }),
                 Event::KeyUp {
                     keycode,
                     keymod,
                     repeat,
                     ..
-                } => {
-                    if let Some(valid_keycode) = keycode {
-                        Some(SimulatorEvent::KeyUp {
-                            keycode: valid_keycode,
-                            keymod,
-                            repeat,
-                        })
-                    } else {
-                        None
-                    }
-                }
+                } => keycode.map(|valid_keycode| SimulatorEvent::KeyUp {
+                    keycode: valid_keycode,
+                    keymod,
+                    repeat,
+                }),
                 Event::MouseButtonUp {
                     x, y, mouse_btn, ..
                 } => {


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] ~~Add an example where applicable~~
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

Hi, I noticed that the version of `image` this crate depends on in the published release is 0.23.4 (can be seen on the [crates.io page](https://crates.io/crates/embedded-graphics-simulator/0.6.0/dependencies) rather than the 0.24.7 promised by the changelog. In the meantime, of course, there's been another version out so I've bumped the 3 now outdated dependencies to their latest versions.

I've also fixed some clippy warnings - let me know if you'd prefer that commit to be moved to a separate PR or if it's okay bundled in with this one.
