### PR TITLE
Remove unused fixed_point feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Removed
+
+- **(breaking)** [#57](https://github.com/embedded-graphics/simulator/pull/57) Remove unused `fixed_point` feature.
+
 ## [0.7.0] - 2024-09-10
+
+### Changed
 
 - **(breaking)** [#55](https://github.com/embedded-graphics/simulator/pull/55) Bump the following crate dependencies: `image` to 0.25.1, `base64` to 0.22.1, `sdl2` to 0.37.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,4 @@ ouroboros = { version = "0.18.0", optional = true }
 
 [features]
 default = ["with-sdl"]
-fixed_point = ["embedded-graphics/fixed_point"]
 with-sdl = ["sdl2", "ouroboros"]


### PR DESCRIPTION
This PR removes the `fixed_point` feature from this crate. I'm not sure why that feature existed in the first place, because it only enabled the feature in the `embedded-graphics` crate without being used in this crate. This should fix the CI build but not the underlying problem (see https://github.com/embedded-graphics/embedded-graphics/issues/765 for more details).
