### PR TITLE
expose sdl context for external use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added `Window::context` to expose the SDL context for external use, for example audio playback or recording.
+
 ## [0.7.0] - 2024-09-10
 
 - **(breaking)** [#55](https://github.com/embedded-graphics/simulator/pull/55) Bump the following crate dependencies: `image` to 0.25.1, `base64` to 0.22.1, `sdl2` to 0.37.0

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -45,6 +45,12 @@ impl Window {
         }
     }
 
+    /// Get raw SDL context for external use (e.g. audio context).
+    #[cfg(feature = "with-sdl")]
+    pub fn context(&mut self) -> sdl2::Sdl {
+        self.sdl_window.as_mut().unwrap().context()
+    }
+
     /// Updates the window.
     pub fn update<C>(&mut self, display: &SimulatorDisplay<C>)
     where

--- a/src/window/sdl_window.rs
+++ b/src/window/sdl_window.rs
@@ -9,7 +9,7 @@ use sdl2::{
     pixels::PixelFormatEnum,
     render::{Canvas, Texture, TextureCreator},
     video::WindowContext,
-    EventPump,
+    EventPump, Sdl,
 };
 
 use crate::{OutputImage, OutputSettings, SimulatorDisplay};
@@ -66,6 +66,7 @@ pub enum SimulatorEvent {
 }
 
 pub struct SdlWindow {
+    sdl_context: Sdl,
     canvas: Canvas<sdl2::video::Window>,
     event_pump: EventPump,
     window_texture: SdlWindowTexture,
@@ -106,11 +107,16 @@ impl SdlWindow {
         .build();
 
         Self {
+            sdl_context,
             canvas,
             event_pump,
             window_texture,
             size,
         }
+    }
+
+    pub fn context(&self) -> Sdl {
+        self.sdl_context.clone()
     }
 
     pub fn update(&mut self, framebuffer: &OutputImage<Rgb888>) {

--- a/src/window/sdl_window.rs
+++ b/src/window/sdl_window.rs
@@ -66,7 +66,6 @@ pub enum SimulatorEvent {
 }
 
 pub struct SdlWindow {
-    sdl_context: Sdl,
     canvas: Canvas<sdl2::video::Window>,
     event_pump: EventPump,
     window_texture: SdlWindowTexture,
@@ -76,13 +75,13 @@ pub struct SdlWindow {
 impl SdlWindow {
     pub fn new<C>(
         display: &SimulatorDisplay<C>,
+        sdl_context: &mut Sdl,
         title: &str,
         output_settings: &OutputSettings,
     ) -> Self
     where
         C: PixelColor + Into<Rgb888>,
     {
-        let sdl_context = sdl2::init().unwrap();
         let video_subsystem = sdl_context.video().unwrap();
 
         let size = output_settings.framebuffer_size(display);
@@ -107,16 +106,11 @@ impl SdlWindow {
         .build();
 
         Self {
-            sdl_context,
             canvas,
             event_pump,
             window_texture,
             size,
         }
-    }
-
-    pub fn context(&self) -> Sdl {
-        self.sdl_context.clone()
     }
 
     pub fn update(&mut self, framebuffer: &OutputImage<Rgb888>) {


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [x] Check that you've added passing tests and documentation
- [x] Add an example where applicable
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

For embedded audio projects with a display, simulators on a computer would be nice if they can also produce sound, not just the display content. SDL cannot be initialized for a second time to get the audio part. That is, the embedded-graphics simulator should be able to share the original context, available during its initialization so the caller can utilize it for audio purposes.

My original idea was to extend the simulator with audio aware methods, but instead the exposure of the context itself was suggested:
https://matrix.to/#/!SfJCDXZbMHXkPovtKL:matrix.org/$hWJf8zMpHm7WrH49Dj72FC97jbXbsGC-d7Vx5D2Im68?via=matrix.org&via=tchncs.de&via=grusbv.com
