### PR TITLE
Update `sdl2` crate dependency to 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **(breaking)** [#66](https://github.com/embedded-graphics/simulator/pull/66) `OutputSettings::max_fps` has been removed, use `Window::set_max_fps` or `MultiWindow::set_max_fps` instead.
 - **(breaking)** [#66](https://github.com/embedded-graphics/simulator/pull/66) Renamed `OutputImage::update` to `OutputImage::draw_display` and added `position` parameter.
 - [#66](https://github.com/embedded-graphics/simulator/pull/66) Changed `Window::events` to take `&self` instead of `&mut self`.
+- **(breaking)** [#69](https://github.com/embedded-graphics/simulator/pull/69) Bump `sdl2` crate dependency to 0.38.0.
 
 ## [0.7.0] - 2024-09-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ circle-ci = { repository = "embedded-graphics/simulator", branch = "master" }
 image = { version = "0.25.1", default-features=false, features=["png"] }
 base64 = "0.22.1"
 embedded-graphics = "0.8.1"
-sdl2 = { version = "0.37.0", optional = true }
+sdl2 = { version = "0.38.0", optional = true }
 ouroboros = { version = "0.18.0", optional = true }
 
 [features]


### PR DESCRIPTION
Thank you for helping out with embedded-graphics-simulator development! Please:

- [x] Check that you've added passing tests and documentation
- [ ] ~Add an example where applicable~
- [x] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, etc) if your changes affect the **public API**
- [x] Run `rustfmt` on the project
- [x] Run `just build` (Linux/macOS only) and make sure it passes. If you use Windows, check that CI passes once you've opened the PR.

## PR description

I’d like to have the re-exported `sdl2` crate dependency updated to the latest version. With Rust 1.90.0, I’ve started getting crashes running my [examples] that use the simulator due to a change that was made to the compiler: rust-lang/rust#141759

There’s probably an issue with `sdl2-compat` in my Linux installation, and `sdl2` 0.37.0 isn’t handling some error gracefully:

```
trying to construct an enum from an invalid value 0x207
```

My debug builds are crashing because of [event.rs#L336] — already known about and fixed 9 months ago: [rust-sdl2#1444]

Updating `sdl2` to 0.38.0 would allow me to continue running apps that use the simulator the same way they used to do when built with Rust 1.89.0 and earlier, irrespective of the fact that there’s `an invalid value 0x207` in the app.

[examples]: https://github.com/iddey/mplusfonts/tree/main/examples
[event.rs#L336]: https://github.com/Rust-SDL2/rust-sdl2/blob/0.37.0/src/sdl2/event.rs#L336
[rust-sdl2#1444]: https://github.com/Rust-SDL2/rust-sdl2/pull/1444#pullrequestreview-2542609061