### PR TITLE
Add support for non-square pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- **(breaking)** [#71](https://github.com/embedded-graphics/simulator/pull/71) Added support for non-square pixels.
+
+### Fixed
+
+- [#71](https://github.com/embedded-graphics/simulator/pull/71) Fixed pixel spacing for unscaled outputs.
+
 ## [0.8.0] - 2025-10-10
 
 ### Added

--- a/src/display.rs
+++ b/src/display.rs
@@ -102,7 +102,7 @@ impl<C: PixelColor> SimulatorDisplay<C> {
     /// [`pixel_spacing`](OutputSettings::pixel_spacing) settings to determine
     /// the size of this display in output pixels.
     pub fn output_size(&self, output_settings: &OutputSettings) -> Size {
-        self.size * output_settings.scale
+        self.size.component_mul(output_settings.scale)
             + self.size.saturating_sub(Size::new_equal(1)) * output_settings.pixel_spacing
     }
 }

--- a/src/output_image.rs
+++ b/src/output_image.rs
@@ -64,7 +64,7 @@ where
         )
         .unwrap();
 
-        if output_settings.scale == 1 {
+        if output_settings.scale == Size::new(1, 1) && output_settings.pixel_spacing == 0 {
             display
                 .bounding_box()
                 .points()
@@ -78,16 +78,16 @@ where
                 .draw(self)
                 .unwrap();
         } else {
-            let pixel_pitch = (output_settings.scale + output_settings.pixel_spacing) as i32;
-            let pixel_size = Size::new(output_settings.scale, output_settings.scale);
-
             for p in display.bounding_box().points() {
                 let raw_color = display.get_pixel(p).into();
                 let themed_color = output_settings.theme.convert(raw_color);
                 let output_color = C::from(themed_color);
 
                 self.fill_solid(
-                    &Rectangle::new(p * pixel_pitch + position, pixel_size),
+                    &Rectangle::new(
+                        p.component_mul(output_settings.pixel_pitch()) + position,
+                        output_settings.scale,
+                    ),
                     output_color,
                 )
                 .unwrap();


### PR DESCRIPTION
Add support for non-square pixels, using fractional numbers

for example, the display I'm working rn has a 2:3 pixel aspect ratio, this makes the simulator realistic to the device
